### PR TITLE
Fix missing } in config/services.js

### DIFF
--- a/config/services.js
+++ b/config/services.js
@@ -31,4 +31,5 @@ module.exports = {
       clientSecret: Env.get('FB_CLIENT_SECRET'),
       redirectUri: `${Env.get('APP_URL')}/authenticated/facebook`
     },
+  }
 }


### PR DESCRIPTION
This PR will fix missing `}` typo introduced in previous PR