### PR TITLE
First FB connect, then allow request 'send'

### DIFF
--- a/app/Controllers/Http/TaskController.js
+++ b/app/Controllers/Http/TaskController.js
@@ -50,7 +50,7 @@ class TaskController {
     task.lat = request.input("lat");
     task.lng = request.input("lng");
     task.category = request.input("category");
-    task.fbid = '2957526370935693';
+    task.fbid = request.input("fbid");
     await task.save();
   }
 

--- a/resources/assets/scripts/app.js
+++ b/resources/assets/scripts/app.js
@@ -283,15 +283,8 @@ Jelpi.asks = class {
     this.parent.locate( this.render.bind(this) );
   }
   render(locationResult) {
-    let randomType = () => {
-      let needs = [ 'Food', 'Medicine', 'Supplies' ];
-      return needs[ Math.floor( Math.random() * needs.length ) ];
-    },
-    randomLocationDelta = () => {
-      let random = Math.pow( Math.random(), 10 );
-      return random * ( Math.random() < .5 ? -1 : 1 );
-    };
     axios.get("/tasks").then(res => {
+      this.data = [];
       for (let i = 0; i <= res.data.length; i++) {
         if (res.data[i]) {
           this.data.push({
@@ -798,7 +791,7 @@ Jelpi.cancelButton = class {
     this.parent = parent;
   }
   init() {
-    this.element().addEventListener('click', this.onClick.bind(this));
+    this.element() && this.element().addEventListener('click', this.onClick.bind(this));
   }
   element() {
     return document.getElementById('cancel');
@@ -814,7 +807,7 @@ Jelpi.sendButton = class {
     this.parent = parent;
   }
   init() {
-    this.element().addEventListener('click', this.onClick.bind(this));
+    this.element() && this.element().addEventListener('click', this.onClick.bind(this));
   }
   element() {
     return document.getElementById('send');
@@ -828,7 +821,8 @@ Jelpi.sendButton = class {
     if (!this.parent.parent.location) {
       return;
     }
-    let nam = document.getElementById("ask-name").value;
+    let nam = document.getElementById("ask_name").value;
+    let fid = document.getElementById("fb_id").value;
     let cat = document
       .querySelector("needs > div:not(.hidden)")
       .getAttribute("data-type");
@@ -838,11 +832,10 @@ Jelpi.sendButton = class {
         name: nam,
         lat: this.parent.parent.location.coords.latitude,
         lng: this.parent.parent.location.coords.longitude,
-        category: cat
+        category: cat,
+        fbid: fid
       })
       .then((response) => {
-        console.log(response);
-        document.getElementById("ask-name").value = '';
         this.parent.onCancel();
       })
       .catch((error) => {
@@ -860,7 +853,7 @@ Jelpi.iCanHelpButton = class {
     this.parent = parent;
   }
   init() {
-    this.element().addEventListener('click', this.onClick.bind(this));
+    this.element() && this.element().addEventListener('click', this.onClick.bind(this));
   }
   element() {
     return document.getElementById('icanhelp');

--- a/resources/views/index.edge
+++ b/resources/views/index.edge
@@ -12,6 +12,9 @@
 </head>
 <body>
 <menu><hamburger><slice></slice><slice></slice><slice></slice></hamburger><table><td><a href='.'><table><td>Get Help</td></table></a><a href='#givehelp'><table><td>Give Help</td></table></a><a href='#safety'><table><td>Safety</td></table></a><a href='#about'><table><td>About</td></table></a></td></table></menu>
+@if(flashMessage('notification'))
+  <span style="background: green; color:white;width:100%">{{ flashMessage('notification') }}</span>
+@endif
 <table class='section gethelp' id='section0'>
   <tr>
     <td>
@@ -25,13 +28,27 @@
       <needs>
         <div data-type='medicine'><table><tr><td>I need medicine</td></tr></table></div><div data-type='food'><table><tr><td>I need food</td></tr></table></div><div data-type='supplies'><table><tr><td>I need supplies</td></tr></table></div>
       </needs>
+      @if(!fb_id)
+      <form>
+        <h3>Connect with Facebook to get started!</h3>
+        <inputwrap><button onclick="window.open('facebook','_self');event.preventDefault();event.stopPropagation();" class='action'>Connect</button><fx1></fx1><fx2></fx2></inputwrap>
+        <inputwrap></inputwrap>
+        <inputwrap></inputwrap>
+      </form>
+      @else
       <form>
         <destroyed><div>:-(</div>We couldn't determine your location!</destroyed>
-        <inputwrap><input type='text' id='ask-name'><fx1></fx1><fx2></fx2><placeholder>My name</placeholder></inputwrap>
+        <inputwrap><input type='text' id='ask_name' value="{{ name }}"><fx1></fx1><fx2></fx2>
+        @if(!name)
+          <placeholder>My name</placeholder>
+        @endif
+        </inputwrap>
         <inputwrap class='location locating'><span>Current Location</span><placeholder class='busy'>Locating</placeholder><placeholder class='done'>Location</placeholder></inputwrap>
+        <input type='hidden' id='fb_id' value="{{ fb_id }}">
         <inputwrap><button id='cancel' class='action'>Cancel</button><fx1></fx1><fx2></fx2></inputwrap>
         <inputwrap><button id='send' class='action'>Send</button><fx1></fx1><fx2></fx2></inputwrap>
       </form>
+      @endif
     </td>
   </tr>
 </table>

--- a/start/routes.js
+++ b/start/routes.js
@@ -22,10 +22,10 @@ Route.get('tasks', 'TaskController.index')
 Route.post('tasks', 'TaskController.store')
 
 Route.get('facebook', async ({ ally }) => {
-  await ally.driver('facebook').redirect()
+  await ally.driver('facebook').redirect();
 })
 
-Route.get('authenticated/facebook', async ({ ally, response }) => {
-  const fb_user = await ally.driver('facebook').getUser()
-  return response.redirect('back', { fb_user: fb_user })
+Route.get('authenticated/facebook', async ({ ally, view }) => {
+  const fb_user = await ally.driver('facebook').getUser();
+  return view.render('index', { name: fb_user.getName(), fb_id: fb_user.getId() })
 })


### PR DESCRIPTION
Despite several tries (with different redirects and session stores) there doesn't seem to be any easy way to streamline the sending of "help request" and FB login (& redirect). So...

This PR adds FB connect -button that users needs to fulfill to be able to add a request. Basically going back to Arun's initial suggestion (to also get `name` from FB)