### PR TITLE
Fix sqlite problems

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 .git
 node_modules
+database/db

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -25,6 +25,7 @@ jobs:
       uses: appleboy/ssh-action@master
       env:
         APP_KEY: ${{ secrets.APP_KEY }}
+        FB_CLIENT_ID: ${{ secrets.FB_CLIENT_ID }}
         FB_CLIENT_SECRET: ${{ secrets.FB_CLIENT_SECRET }}
         REGISTRY_ACCESS_TOKEN: ${{ secrets.REGISTRY_ACCESS_TOKEN }}
       with:
@@ -32,12 +33,16 @@ jobs:
         username: ubuntu
         command_timeout: 5m
         key: ${{ secrets.SERVER_ACCESS_KEY }}
-        envs: GITHUB_REF,APP_KEY,FB_CLIENT_SECRET,REGISTRY_ACCESS_TOKEN
+        envs: GITHUB_REF,APP_KEY,FB_CLIENT_ID,FB_CLIENT_SECRET,REGISTRY_ACCESS_TOKEN
         script: |
           docker login docker.pkg.github.com --username mcsneaky --password $REGISTRY_ACCESS_TOKEN
           docker pull docker.pkg.github.com/eka-foundation/jelpi/core:$(echo $GITHUB_REF | cut -d '/' -f3)
           docker stop jelpi-core; docker rm jelpi-core;
           docker run -d -p 127.0.0.1:3333:3333 --name jelpi-core --restart always \
+            -v ${PWD}/jelpi-db:/home/node/app/database/db
             -e APP_KEY=${APP_KEY} \
+            -e DB_DATABASE=jelpi \
+            -e FB_CLIENT_ID=${FB_CLIENT_ID} \
             -e FB_CLIENT_SECRET=${FB_CLIENT_SECRET} \
             docker.pkg.github.com/eka-foundation/jelpi/core:$(echo $GITHUB_REF | cut -d '/' -f3)
+          sleep 5; docker exec jelpi-core node ace migration:run --force

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,6 @@ ENV PORT=3333
 # Set app key at start time
 ENV APP_KEY=
 # Make directory for app to live in
-# It's important to set user first or owner will be root
 RUN mkdir -p /home/node/app/
 # Set working directory
 WORKDIR /home/node/app
@@ -37,11 +36,7 @@ COPY package*.json ./
 RUN npm ci --only=production
 # Copy over source code files
 COPY . .
-# Ensure Node can edit DB and public assets
-RUN chown -R node:node /home/node/app/
 # Expose port 3333 to outside world
 EXPOSE 3333
-# Use non-root user
-USER node
 # Start server up
 CMD [ "node", "./server.js" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,6 @@ ENV HOST=0.0.0.0
 ENV PORT=3333
 # Set app key at start time
 ENV APP_KEY=
-# Use non-root user
-USER node
 # Make directory for app to live in
 # It's important to set user first or owner will be root
 RUN mkdir -p /home/node/app/
@@ -39,7 +37,11 @@ COPY package*.json ./
 RUN npm ci --only=production
 # Copy over source code files
 COPY . .
+# Ensure Node can edit DB and public assets
+RUN chown -R node:node /home/node/app/
 # Expose port 3333 to outside world
 EXPOSE 3333
+# Use non-root user
+USER node
 # Start server up
 CMD [ "node", "./server.js" ]

--- a/config/database.js
+++ b/config/database.js
@@ -32,7 +32,7 @@ module.exports = {
   sqlite: {
     client: 'sqlite3',
     connection: {
-      filename: Helpers.databasePath(`${Env.get('DB_DATABASE', 'development')}.sqlite`)
+      filename: Helpers.databasePath(`/db/${Env.get('DB_DATABASE', 'development')}.sqlite`)
     },
     useNullAsDefault: true
   },


### PR DESCRIPTION
This PR makes SQLite storage persist thro deployments (maps it out of container to host)

Also removes Node user, since host mapped database will not work with Node user in container without manual file / folder permission changes