### PR TITLE
Add production APP_URL (needed with FB connect)

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -41,6 +41,7 @@ jobs:
           docker run -d -p 127.0.0.1:3333:3333 --name jelpi-core --restart always \
             -v ${PWD}/jelpi-db:/home/node/app/database/db \
             -e APP_KEY=${APP_KEY} \
+            -e APP_URL=https://www.jelpi.org \
             -e DB_DATABASE=jelpi \
             -e FB_CLIENT_ID=${FB_CLIENT_ID} \
             -e FB_CLIENT_SECRET=${FB_CLIENT_SECRET} \


### PR DESCRIPTION
FB connect requires a `redirect_url` which is defined in `services.js`. The current redirect url uses `Env.get('APP_URL')`.

This PR sets APP_URL in CI workflow to [https://www.jelpi.org](https://www.jelpi.org)